### PR TITLE
Testing improvements

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -32,7 +32,7 @@ export interface Printer {
 /**
  * A class which allows for colorful, tagged logging
  */
-class Logger {
+export class Logger {
   // The log level threshold, below which no messages are printed
   private level: number;
 

--- a/test/bite-log-test.ts
+++ b/test/bite-log-test.ts
@@ -1,32 +1,40 @@
-import Logger, { Level } from 'bite-log';
+import * as BL from 'bite-log';
+// tslint:disable-next-line:no-duplicate-imports
+import { LoggerWithStyles } from 'bite-log';
 
-QUnit.module('bite-log tests');
+QUnit.module('Public API is correct');
 
-QUnit.test('Logger', assert => {
-  const logger = new Logger(Level.warn); // only warns and error
-  // console.log('%c Oh my heavens! ', 'background: #222; color: #bada55');
-  logger.debug(' (debug) Oh my heavens');
-  logger.log(' (log) Oh my heavens');
-  logger.warn(' (warn) Oh my heavens');
-  logger.error(' (error) Oh my heavens');
-  assert.ok(logger, 'logger exists');
+QUnit.test('Logger as a default export', assert => {
+  assert.equal(typeof BL.default, 'function', 'it\'s a function');
+  assert.deepEqual(
+    Object.keys(BL),
+    ['default'],
+    'aside from types, there is a "default" export'
+  );
+  assert.deepEqual(
+    typeof BL.default.prototype,
+    'object',
+    'Logger looks like a class'
+  );
+  assert.ok(new BL.default(), 'Logger can be used with the `new` keyword');
 });
 
+QUnit.test('Level as a named export', assert => {
+  assert.equal(BL.Level.error, 1, 'Level.error = 1');
+  assert.equal(BL.Level.warn, 2, 'Level.error = 2');
+  assert.equal(BL.Level.log, 3, 'Level.error = 3');
+  assert.equal(BL.Level.debug, 4, 'Level.error = 4');
+});
 
-// logger
+/**
+ * The following are just TS interface/type tests. Their failures may be caught
+ * by running `npm run-script problems`
+ */
 
-// logger
-//   .bgWhite.red.txt('my message')
-//   .blue.large.txt('another');
-//   .debug();
-
-// logger
-//   .bgWhite.red.txt('my message')
-//   .blue.large.debug('another');
-
-
-// msgsAndStyles
-// [
-//   ['hello', 'color: red'],
-//   ['Im yellow', 'background: yellow']
-// ]
+const x: LoggerWithStyles = new BL.default(4);
+// tslint:disable-next-line:no-unused-expression
+x.red;
+// tslint:disable-next-line:no-unused-expression
+x.bgBeige;
+// tslint:disable-next-line:no-unused-expression
+x.bold;

--- a/test/colors-test.ts
+++ b/test/colors-test.ts
@@ -1,11 +1,9 @@
 import Logger, { Level } from 'bite-log';
-import { logCountAssert, makeTestPrinter } from './test-helpers';
-
+import { makeTestLogger } from './test-helpers';
 QUnit.module('The ability to color console messages');
 
 QUnit.test('Logger in red works', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer);
+  const { logger, printer } = makeTestLogger(Level.debug);
   assert.ok(logger.red instanceof Logger, 'logger.red is a logger');
   assert.equal(
     typeof logger.red.log,
@@ -14,19 +12,15 @@ QUnit.test('Logger in red works', assert => {
   );
   logger.red.log('foo');
 
-  logCountAssert(
-    {
-      message: 'after logging in red, we should see one log message',
-      assert,
-      printer
-    },
-    { e: 0, w: 0, l: 1, d: 0 }
+  assert.logCount(
+    printer,
+    { e: 0, w: 0, l: 1, d: 0 },
+    'after logging in red, we should see one log message'
   );
 });
 
 QUnit.test('Logger in blue background works', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer);
+  const { logger, printer } = makeTestLogger(Level.debug);
   assert.ok(logger.bgBlue instanceof Logger, 'logger.bgBlue is a logger');
   assert.equal(
     typeof logger.bgBlue.log,
@@ -35,20 +29,9 @@ QUnit.test('Logger in blue background works', assert => {
   );
   logger.bgBlue.log('my background is blue');
 
-  logCountAssert(
-    {
-      message:
-        'after logging with blue background, we should see one log message',
-      assert,
-      printer
-    },
-    { e: 0, w: 0, l: 1, d: 0 }
+  assert.logCount(
+    printer,
+    { e: 0, w: 0, l: 1, d: 0 },
+    'after logging with blue background, we should see one log message'
   );
 });
-
-// logger.red().log('foo')
-
-// logger
-//   .bgWhite.red.txt('my message')
-//   .blue.large.txt('another');
-//   .debug();

--- a/test/custom-css-test.ts
+++ b/test/custom-css-test.ts
@@ -1,16 +1,20 @@
-import Logger, { Level } from 'bite-log';
-import { makeTestPrinter } from './test-helpers';
+import { Level } from 'bite-log';
+import { makeTestLogger } from './test-helpers';
 
 QUnit.module('Custom CSS test');
 QUnit.test('Custom CSS can be applied', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer);
+  const {
+    logger,
+    printer: {
+      messages: { warn }
+    }
+  } = makeTestLogger(Level.debug);
 
   // log something with custom css
   logger.css('color: #aaa').warn('a warning');
   // get the first warning message (an array of arguments
-  const firstWarning = printer.messages.warn[0];
-  const [firstWarnMessage, firstWarnStyle ] = firstWarning;
+  const firstWarning = warn[0];
+  const [firstWarnMessage, firstWarnStyle] = firstWarning;
   assert.ok(firstWarnMessage.indexOf('a warning') >= 0, 'Message is correct');
   assert.equal(firstWarnStyle, 'color: #aaa', 'Style is correct');
 });

--- a/test/exports-test.ts
+++ b/test/exports-test.ts
@@ -3,5 +3,5 @@ import * as allExports from 'bite-log';
 QUnit.module('the right things are exported from bite-log');
 
 QUnit.test('Logger exists', assert => {
-    assert.ok(allExports.default, 'default export exists');
+  assert.ok(allExports.default, 'default export exists');
 });

--- a/test/logging-objects-test.ts
+++ b/test/logging-objects-test.ts
@@ -1,16 +1,16 @@
-import Logger, { Level } from 'bite-log';
-import { logCountAssert, makeTestPrinter } from './test-helpers';
+import { Level } from 'bite-log';
+import { makeTestLogger } from './test-helpers';
 
 QUnit.module('Objects, arrays, functions, etc... should be loggable');
 
 QUnit.test('I can log an object after my string message', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer); // only warns and error
+  const { logger, printer } = makeTestLogger(Level.debug);
 
   logger.log('Here are some numbers. They are increasing', [1, 2, 3, 4]);
-  logCountAssert(
-    { message: 'after a debug', assert, printer },
-    { l: 1 } // one log message has been printed
+  assert.logCount(
+    printer,
+    { l: 1 }, // one log message has been printed
+    'after a debug'
   );
 
   assert.deepEqual(
@@ -27,13 +27,13 @@ QUnit.test('I can log an object after my string message', assert => {
 });
 
 QUnit.test('Formatting is applied to the string', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer); // only warns and error
+  const { printer, logger } = makeTestLogger(Level.debug);
 
   logger.red.log('Here are some numbers. They are increasing', [1, 2, 3, 4]);
-  logCountAssert(
-    { message: 'after a debug', assert, printer },
-    { l: 1 } // one log message has been printed
+  assert.logCount(
+    printer,
+    { l: 1 }, // one log message has been printed
+    'after a debug'
   );
 
   assert.deepEqual(
@@ -52,17 +52,18 @@ QUnit.test('Formatting is applied to the string', assert => {
 QUnit.test(
   'Formatting is applied to all strings passed to the logger',
   assert => {
-    const printer = makeTestPrinter();
-    const logger = new Logger(Level.debug, printer); // only warns and error
+    const { logger, printer } = makeTestLogger(Level.debug);
 
     logger.red.log(
       'Here are some numbers ',
       [1, 2, 3, 4],
       'They are increasing'
     );
-    logCountAssert(
-      { message: 'after a debug', assert, printer },
-      { l: 1 } // one log message has been printed
+
+    assert.logCount(
+      printer,
+      { l: 1 }, // one log message has been printed
+      'after a debug'
     );
 
     // logger.red.txt('Here are some numbers. They are increasing')

--- a/test/logging-test.ts
+++ b/test/logging-test.ts
@@ -1,54 +1,36 @@
-import Logger, { Level } from 'bite-log';
-import { logCountAssert, makeTestPrinter } from './test-helpers';
+import { Level } from 'bite-log';
+import { makeTestLogger } from './test-helpers';
 
 QUnit.module('Logging through the printer');
 
 QUnit.test('Logger @ level 4', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.debug, printer); // only warns and error
+  const { logger, printer } = makeTestLogger(Level.debug);
   logger.warn('a warning');
-  logCountAssert(
-    { message: 'after a warning', assert, printer },
-    { e: 0, w: 1, l: 0, d: 0 }
-  );
+  assert.logCount(printer, { e: 0, w: 1, l: 0, d: 0 }, 'after a warning');
   logger.error('an error');
-  logCountAssert(
-    { message: 'after an error', assert, printer },
-    { e: 1, w: 1, l: 0, d: 0 }
-  );
+  assert.logCount(printer, { e: 1, w: 1, l: 0, d: 0 }, 'after an error');
   logger.log('a log');
-  logCountAssert(
-    { message: 'after a log', assert, printer },
-    { e: 1, w: 1, l: 1, d: 0 }
-  );
+  assert.logCount(printer, { e: 1, w: 1, l: 1, d: 0 }, 'after a log');
   logger.debug('a debug');
-  logCountAssert(
-    { message: 'after a debug', assert, printer },
-    { e: 1, w: 1, l: 1, d: 1 }
-  );
+  assert.logCount(printer, { e: 1, w: 1, l: 1, d: 1 }, 'after a debug');
 });
 
 QUnit.test('Logger @ level 2', assert => {
-  const printer = makeTestPrinter();
-  const logger = new Logger(Level.warn, printer); // only warns and error
+  const { logger, printer } = makeTestLogger(Level.warn);
   logger.warn('a warning');
-  logCountAssert(
-    { message: 'after logging a warning', assert, printer },
-    { e: 0, w: 1, l: 0, d: 0 }
+  assert.logCount(
+    printer,
+    { e: 0, w: 1, l: 0, d: 0 },
+    'after logging a warning'
   );
   logger.error('an error');
-  logCountAssert(
-    { message: 'after logging an error', assert, printer },
-    { e: 1, w: 1, l: 0, d: 0 }
+  assert.logCount(
+    printer,
+    { e: 1, w: 1, l: 0, d: 0 },
+    'after logging an error'
   );
   logger.log('a log');
-  logCountAssert(
-    { message: 'after logging', assert, printer },
-    { e: 1, w: 1, l: 0, d: 0 }
-  );
+  assert.logCount(printer, { e: 1, w: 1, l: 0, d: 0 }, 'after logging');
   logger.debug('a debug');
-  logCountAssert(
-    { message: 'after logging a debug', assert, printer },
-    { e: 1, w: 1, l: 0, d: 0 }
-  );
+  assert.logCount(printer, { e: 1, w: 1, l: 0, d: 0 }, 'after logging a debug');
 });

--- a/test/tagged-logging-test.ts
+++ b/test/tagged-logging-test.ts
@@ -1,34 +1,51 @@
-import Logger, { Level } from 'bite-log';
-import { logCountAssert, makeTestPrinter } from './test-helpers';
+import { Level } from 'bite-log';
+import { makeTestLogger } from './test-helpers';
 
 QUnit.module('Tagged logging');
 
 QUnit.test(
   'Pushing a tag results in the log mesages being prefixed',
   assert => {
-    const printer = makeTestPrinter();
-    const logger = new Logger(Level.debug, printer);
-    logger.log('hello');          // "hello"
-    logger.log('world');          // "world"
+    const { logger, printer } = makeTestLogger(Level.debug);
+    logger.log('hello'); // "hello"
+    logger.log('world'); // "world"
     logger.pushPrefix('foo');
-    logger.log('goodbye');        // "[foo]: goodbye"
-    logger.log('mars');           // "[foo]: mars"
+    logger.log('goodbye'); // "[foo]: goodbye"
+    logger.log('mars'); // "[foo]: mars"
     logger.pushPrefix('bar');
-    logger.log('(and saturn!)');  // "[foo][bar]: (and saturn)!"
+    logger.log('(and saturn!)'); // "[foo][bar]: (and saturn)!"
     logger.popPrefix();
     logger.popPrefix();
-    logger.log('but not pluto');  // "but not pluto"
-    logCountAssert(
-      { message: 'after logging four things', assert, printer },
-      { l: 6 }
-    );
+    logger.log('but not pluto'); // "but not pluto"
+    assert.logCount(printer, { l: 6 }, 'after logging four things');
     const logs = printer.messages.log;
-    assert.ok(logs[0].join('').indexOf('foo') < 0, 'First message has no "foo" tag');
-    assert.ok(logs[1].join('').indexOf('foo') < 0, 'Second message has no "foo" tag');
-    assert.ok(logs[2].join('').indexOf('foo') >= 0, 'Third message has a "foo" tag');
-    assert.ok(logs[3].join('').indexOf('foo') >= 0, 'Fourth message has a "foo" tag');
-    assert.ok(logs[4].join('').indexOf('foo') >= 0, 'Fifth message has a "foo" tag');
-    assert.ok(logs[4].join('').indexOf('bar') >= 0, 'Fifth message has a "bar" tag');
-    assert.ok(logs[5].join('').indexOf('foo') < 0, 'Sixth message has no "foo" tag');
+    assert.ok(
+      logs[0].join('').indexOf('foo') < 0,
+      'First message has no "foo" tag'
+    );
+    assert.ok(
+      logs[1].join('').indexOf('foo') < 0,
+      'Second message has no "foo" tag'
+    );
+    assert.ok(
+      logs[2].join('').indexOf('foo') >= 0,
+      'Third message has a "foo" tag'
+    );
+    assert.ok(
+      logs[3].join('').indexOf('foo') >= 0,
+      'Fourth message has a "foo" tag'
+    );
+    assert.ok(
+      logs[4].join('').indexOf('foo') >= 0,
+      'Fifth message has a "foo" tag'
+    );
+    assert.ok(
+      logs[4].join('').indexOf('bar') >= 0,
+      'Fifth message has a "bar" tag'
+    );
+    assert.ok(
+      logs[5].join('').indexOf('foo') < 0,
+      'Sixth message has no "foo" tag'
+    );
   }
 );

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,6 +1,14 @@
-import { Printer } from 'bite-log';
+import Logger, { Level, LoggerWithStyles, Printer } from 'bite-log';
 
-export function makeTestPrinter(): Printer & { messages: any } {
+export function makeTestLogger(
+  level: Level
+): { logger: LoggerWithStyles; printer: Printer & { messages: any } } {
+  let printer = makeTestPrinter();
+  let logger = new Logger(level, printer);
+  return { printer, logger };
+}
+
+function makeTestPrinter(): Printer & { messages: any } {
   const printer = {
     messages: {
       log: [] as any[][],
@@ -37,53 +45,66 @@ export function makeTestPrinter(): Printer & { messages: any } {
   return printer;
 }
 
-export function logCountAssert(
-  {
-    message,
-    assert,
-    printer
-  }: { message: string; assert: Assert; printer: Printer },
+declare global {
+  interface Assert {
+    logCount(
+      printer: Printer,
+      counts: { e?: number; w?: number; l?: number; d?: number; dir?: number },
+      message?: string
+    ): void;
+  }
+}
+
+QUnit.assert.logCount = function(
+  printer: Printer,
   {
     e,
     w,
     l,
     d,
     dir
-  }: { e?: number; w?: number; l?: number; d?: number; dir?: number }
+  }: { e?: number; w?: number; l?: number; d?: number; dir?: number },
+  message?: string
 ) {
+  const actual: {
+    errors?: number;
+    logs?: number;
+    debugs?: number;
+    warns?: number;
+    dirs?: number;
+  } = {};
+  const expected: {
+    errors?: number;
+    logs?: number;
+    debugs?: number;
+    warns?: number;
+    dirs?: number;
+  } = {};
   if (typeof e !== 'undefined') {
-    assert.equal(
-      (printer as any).messages.error.length,
-      e,
-      `${message}: ${e} error(s) were logged`
-    );
+    expected.errors = e;
+    actual.errors = (printer as any).messages.error.length;
   }
   if (typeof w !== 'undefined') {
-    assert.equal(
-      (printer as any).messages.warn.length,
-      w,
-      `${message}: ${w} warning(s) was logged`
-    );
-  }
-  if (typeof d !== 'undefined') {
-    assert.equal(
-      (printer as any).messages.debug.length,
-      d,
-      `${message}: ${d} debug(s) were logged`
-    );
+    expected.warns = w;
+    actual.warns = (printer as any).messages.warn.length;
   }
   if (typeof l !== 'undefined') {
-    assert.equal(
-      (printer as any).messages.log.length,
-      l,
-      `${message}: ${l} log(s) were logged`
-    );
+    expected.logs = l;
+    actual.logs = (printer as any).messages.log.length;
+  }
+  if (typeof d !== 'undefined') {
+    expected.debugs = d;
+    actual.debugs = (printer as any).messages.debug.length;
   }
   if (typeof dir !== 'undefined') {
-    assert.equal(
-      (printer as any).messages.dir.length,
-      dir,
-      `${message}: ${dir} dir(s) were logged`
-    );
+    expected.dirs = dir;
+    actual.dirs = (printer as any).messages.dir.length;
   }
-}
+
+  this.pushResult({
+    result: JSON.stringify(actual) === JSON.stringify(expected),
+    actual,
+    expected,
+    message: message || 'message counts match'
+  });
+};


### PR DESCRIPTION
Creating a logger for testing is now much simpler, and can be done in one step

```ts
  const { logger, printer } = makeTestLogger(Level.debug);
```
And assertions on log counts can be made more simply
```ts
  assert.logCount(
    printer,
    { l: 1 }, // one log message has been printed
    'after a debug'
  );
```